### PR TITLE
Fix teleportation after session change 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "threlte-xr",
-	"version": "0.0.29",
+	"version": "0.0.30",
 	"license": "MIT",
 	"scripts": {
 		"start": "vite dev --host",

--- a/src/lib/hooks/use-teleport.ts
+++ b/src/lib/hooks/use-teleport.ts
@@ -50,7 +50,6 @@ export const useTeleport = () => {
     offset.y = -y
     offset.z = -z
 
-    
     const pose = xr.getFrame().getViewerPose(baseReferenceSpace)
     if (pose !== undefined) {
       offset.x += pose.transform.position.x

--- a/src/lib/lib/toggle-xr-session.ts
+++ b/src/lib/lib/toggle-xr-session.ts
@@ -1,6 +1,5 @@
 import { session, referenceSpaceType, xr } from '$lib/stores'
 import { getXRSessionOptions } from './get-xr-session-options'
-import { fire } from '$lib/events'
 
 /**
  * Starts / ends an XR session.
@@ -17,7 +16,6 @@ export const toggleXRSession = async (
 ): Promise<XRSession | undefined> => {
   const currentSession = session.current
   const hasSession = currentSession !== undefined
-  console.log(1)
 
   if (force === 'enter' && hasSession) return currentSession
   if (force === 'exit' && !hasSession) return
@@ -32,14 +30,12 @@ export const toggleXRSession = async (
   // Otherwise enter a session
   const options = getXRSessionOptions(referenceSpaceType.current, sessionInit)
   const nextSession = await navigator.xr!.requestSession(sessionMode, options)
-  console.log(nextSession)
 
   if (xr.current === undefined) {
     throw new Error('An <XR> component was not created when attempting to toggle a session.')
   }
 
   await xr.current.setSession(nextSession)
-  console.log(2)
 
   session.set(nextSession)
   return nextSession

--- a/src/lib/lib/toggle-xr-session.ts
+++ b/src/lib/lib/toggle-xr-session.ts
@@ -1,6 +1,6 @@
-import { session, referenceSpaceType } from '$lib/stores'
-import { get } from 'svelte/store'
+import { session, referenceSpaceType, xr } from '$lib/stores'
 import { getXRSessionOptions } from './get-xr-session-options'
+import { fire } from '$lib/events'
 
 /**
  * Starts / ends an XR session.
@@ -15,8 +15,9 @@ export const toggleXRSession = async (
   sessionInit?: (XRSessionInit & { domOverlay?: { root: HTMLElement } | undefined }) | undefined,
   force?: 'enter' | 'exit'
 ): Promise<XRSession | undefined> => {
-  const currentSession = get(session)
+  const currentSession = session.current
   const hasSession = currentSession !== undefined
+  console.log(1)
 
   if (force === 'enter' && hasSession) return currentSession
   if (force === 'exit' && !hasSession) return
@@ -29,8 +30,17 @@ export const toggleXRSession = async (
   }
 
   // Otherwise enter a session
-  const options = getXRSessionOptions(get(referenceSpaceType), sessionInit)
+  const options = getXRSessionOptions(referenceSpaceType.current, sessionInit)
   const nextSession = await navigator.xr!.requestSession(sessionMode, options)
+  console.log(nextSession)
+
+  if (xr.current === undefined) {
+    throw new Error('An <XR> component was not created when attempting to toggle a session.')
+  }
+
+  await xr.current.setSession(nextSession)
+  console.log(2)
+
   session.set(nextSession)
   return nextSession
 }

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -10,3 +10,5 @@ export const session = currentWritable<XRSession | undefined>(undefined)
 export const referenceSpaceType = currentWritable<XRReferenceSpaceType | undefined>(undefined)
 export const activeTeleportController = currentWritable<THREE.XRTargetRaySpace | undefined>(undefined)
 export const pendingTeleportDestination = currentWritable<THREE.Vector3 | undefined>(undefined)
+
+export const xr = currentWritable<THREE.WebXRManager | undefined>(undefined)

--- a/src/lib/xr.svelte
+++ b/src/lib/xr.svelte
@@ -21,7 +21,7 @@ and interaction. This should be placed within a Threlte `<Canvas />`.
 import { onDestroy } from 'svelte';
 import { useThrelte, createRawEventDispatcher, useFrame } from '@threlte/core'
 import type { XRSessionEvent } from './types'
-import { session, referenceSpaceType, isPresenting, isHandTracking, xrFrame, initialized } from './stores'
+import { session, referenceSpaceType, isPresenting, isHandTracking, xrFrame, initialized, xr as xrStore } from './stores'
 
 /**
  * Enables foveated rendering. `Default is `0`
@@ -110,8 +110,6 @@ const updateSession = async (currentSession?: XRSession) => {
   currentSession.addEventListener('inputsourceschange', handleInputSourcesChange)
   currentSession.addEventListener('frameratechange', handleFramerateChange)
 
-  await xr.setSession(currentSession)
-
   xr.setFoveation(foveation)
   
   updateTargetFrameRate(frameRate)
@@ -126,11 +124,18 @@ $: {
   $referenceSpaceType = referenceSpace
 }
 
-$: cleanupSession($session)
-$: updateSession($session)
+let lastSession: XRSession | undefined
+
+$: if (lastSession !== $session) {
+  cleanupSession(lastSession)
+  updateSession($session)
+  lastSession = $session
+}
+
 $: updateTargetFrameRate(frameRate)
 $: xr.setFoveation(foveation)
 
+$xrStore = xr
 $initialized = true
 
 onDestroy(() => {


### PR DESCRIPTION
* Only set the session store after the promise set by `xr.setSession()` resolves
* Reset the viewer pose after a session store change, since the pose returned by `getReferenceSpace()` is calculated after `xr.setSession()`